### PR TITLE
Fix incorrect index used for handling POVs 2 to 4 for DirectInput devices

### DIFF
--- a/Source/Core Providers/SharpDX_DirectInput/DeviceLibrary/DiDeviceLibrary.cs
+++ b/Source/Core Providers/SharpDX_DirectInput/DeviceLibrary/DiDeviceLibrary.cs
@@ -191,48 +191,47 @@ namespace SharpDX_DirectInput.DeviceLibrary
                 }
 
                 deviceReport.Nodes.Add(axisInfo);
+            }
 
-                // ----- Buttons -----
-                var length = joystick.Capabilities.ButtonCount;
-                if (length > 0)
+            // ----- Buttons -----
+            var length = joystick.Capabilities.ButtonCount;
+            if (length > 0)
+            {
+                var buttonInfo = new DeviceReportNode
                 {
-                    var buttonInfo = new DeviceReportNode
+                    Title = "Buttons"
+                };
+                for (var btn = 0; btn < length; btn++)
+                {
+                    buttonInfo.Bindings.Add(GetInputBindingReport(deviceDescriptor, new BindingDescriptor
                     {
-                        Title = "Buttons"
-                    };
-                    for (var btn = 0; btn < length; btn++)
-                    {
-                        buttonInfo.Bindings.Add(GetInputBindingReport(deviceDescriptor, new BindingDescriptor
-                        {
-                            //Index = btn,
-                            Index = (int)Utilities.OffsetsByType[BindingType.Button][btn],
-                            Type = BindingType.Button
-                        }));
-                    }
-
-                    deviceReport.Nodes.Add(buttonInfo);
+                        //Index = btn,
+                        Index = (int)Utilities.OffsetsByType[BindingType.Button][btn],
+                        Type = BindingType.Button
+                    }));
                 }
 
-                // ----- POVs -----
-                var povCount = joystick.Capabilities.PovCount;
-                if (povCount > 0)
-                {
-                    var povsInfo = new DeviceReportNode
-                    {
-                        Title = "POVs"
-                    };
-                    for (var p = 0; p < povCount; p++)
-                    {
-                        var povInfo = new DeviceReportNode
-                        {
-                            Title = "POV #" + (p + 1),
-                            Bindings = PovBindingInfos[p]
-                        };
-                        povsInfo.Nodes.Add(povInfo);
-                    }
-                    deviceReport.Nodes.Add(povsInfo);
-                }
+                deviceReport.Nodes.Add(buttonInfo);
+            }
 
+            // ----- POVs -----
+            var povCount = joystick.Capabilities.PovCount;
+            if (povCount > 0)
+            {
+                var povsInfo = new DeviceReportNode
+                {
+                    Title = "POVs"
+                };
+                for (var p = 0; p < povCount; p++)
+                {
+                    var povInfo = new DeviceReportNode
+                    {
+                        Title = "POV #" + (p + 1),
+                        Bindings = PovBindingInfos[p]
+                    };
+                    povsInfo.Nodes.Add(povInfo);
+                }
+                deviceReport.Nodes.Add(povsInfo);
             }
 
             return deviceReport;

--- a/Source/Core Providers/SharpDX_DirectInput/DiDeviceHandler.cs
+++ b/Source/Core Providers/SharpDX_DirectInput/DiDeviceHandler.cs
@@ -41,7 +41,7 @@ namespace SharpDX_DirectInput
         {
             var type = Utilities.OffsetToType(update.Offset);
             var index = type == BindingType.POV
-                ? update.Offset - JoystickOffset.PointOfViewControllers0
+                ? (update.Offset - JoystickOffset.PointOfViewControllers0) / 4
                 : (int) update.Offset;
             return new[] {new BindingUpdate {Binding = new BindingDescriptor() {Type = type, Index = index}, Value = update.Value}};
         }


### PR DESCRIPTION
Because JoystickOffset.PointOfViewControllers1 - 3 are offset by multiples of 4 from JoystickOffset.PointOfViewControllers0, instead of getting indexes of 0, 1, 2, and 3, indexes used were 0, 4, 8, and 12 respectively. This prevented handling of any input events from POVs 2-4. This fix allows POVs 2-4 to work.

EDIT: Added a commit that fixes an issue which prevents DirectInput capabilities reporting for DI devices that have no axes. PR title has been edited. In hindsight, I should have committed this one on a separate branch and created a separate PR for it, but I can't be bothered to muck about with the commits at this point. I can do that later if it is important enough to do so, but please don't make me.